### PR TITLE
Fix mixed up directory separator

### DIFF
--- a/src/ContaoCommunityAlliance/Composer/Plugin/AbstractInstaller.php
+++ b/src/ContaoCommunityAlliance/Composer/Plugin/AbstractInstaller.php
@@ -247,7 +247,14 @@ abstract class AbstractInstaller extends LibraryInstaller
             }
         }
 
-        return $sources;
+        // prevents mixed up directory separator
+        // replace '/' read from composer.json[extra] with native directory separator
+        $nativeSources = array();
+        foreach ($sources as $key=>$value) {
+            $nativeSources[self::getNativePath($key)] = self::getNativePath($value);
+        }
+        
+        return $nativeSources;
     }
 
     /**


### PR DESCRIPTION
Fixes [SymlinkInstaller->calculateLinkTarget](https://github.com/contao-community-alliance/composer-plugin/blob/master/src/ContaoCommunityAlliance/Composer/Plugin/SymlinkInstaller.php#L165) not calculating correct relative link target on Windows platforms.

Probably fixes #10 and #11 as well (not tested).