### PR TITLE
Follow symlinks in CopyInstaller

### DIFF
--- a/src/ContaoCommunityAlliance/Composer/Plugin/CopyInstaller.php
+++ b/src/ContaoCommunityAlliance/Composer/Plugin/CopyInstaller.php
@@ -129,6 +129,16 @@ class CopyInstaller extends AbstractInstaller
 
             /** @var \SplFileInfo $sourceFile */
             foreach ($files as $targetPath => $sourceFile) {
+                if ($sourceFile->isLink()) {
+                    $this->write(
+                        sprintf(
+                            '<warning>Warning: %s is a symlink and will not get copied.</warning>',
+                            self::unprefixPath($root . DIRECTORY_SEPARATOR, $sourceFile->getPathname())
+                        )
+                    );
+                    continue;
+                }
+
                 $this->writeVerbose(
                     sprintf(
                         '  - cp <info>%s</info>',


### PR DESCRIPTION
This fixes the issue described in contao-community-alliance/composer-client#251

The issue can be reproduced by installing `"madeyourday/contao-rocksolid-icon-picker": "1.0.8"` with `"preferred-install": "dist"`. After that, the error message `Warning: copy(): The first argument to copy() function cannot be a directory in .../CopyInstaller.php on line 140` appears because the installed package includes a symlink to a directory.

This pull request adds the `FilesystemIterator::FOLLOW_SYMLINKS` flag. 

If following symlinks isn’t the right solution you could add

```php
if (is_dir($sourceFile->getRealPath())) {
    continue;
}
```

before [CopyInstaller.php:119](https://github.com/contao-community-alliance/composer-plugin/blob/93ec63563327f63d271fe2012628c94b06d31412/src/ContaoCommunityAlliance/Composer/Plugin/CopyInstaller.php#L119).