### PR TITLE
Check for localconfig instead of just system folder

### DIFF
--- a/src/ContaoCommunityAlliance/Composer/Plugin/Environment.php
+++ b/src/ContaoCommunityAlliance/Composer/Plugin/Environment.php
@@ -106,6 +106,7 @@ class Environment
      */
     public static function isContao($path)
     {
-        return file_exists($path . DIRECTORY_SEPARATOR . 'system/config/localconfig.php');
+        return file_exists($path . DIRECTORY_SEPARATOR . 'system/config/constants.php')
+            || file_exists($path . DIRECTORY_SEPARATOR . 'system/constants.php');
     }
 }

--- a/src/ContaoCommunityAlliance/Composer/Plugin/Environment.php
+++ b/src/ContaoCommunityAlliance/Composer/Plugin/Environment.php
@@ -106,6 +106,6 @@ class Environment
      */
     public static function isContao($path)
     {
-        return is_dir($path . DIRECTORY_SEPARATOR . 'system');
+        return file_exists($path . DIRECTORY_SEPARATOR . 'system/config/localconfig.php');
     }
 }


### PR DESCRIPTION
I had the issue of installing dependencies with composer in a project that organizes multiple custom extensions in the system folder. Because Contao was detected, the plugin was looking for the `constants.php` but could not find it.

Am I correct that every actual installation should have a `localconfig.php`?