### PR TITLE
Use relative paths to symlink Contao legacy modules

### DIFF
--- a/src/Installer/AbstractModuleInstaller.php
+++ b/src/Installer/AbstractModuleInstaller.php
@@ -230,7 +230,8 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
             }
         }
 
-        $workingDir = getcwd(); // preserve the current working directory
+        // Preserve the current working directory
+        $workingDir = getcwd();
 
         // Only actually create the links if the checks are successful to prevent orphans.
         foreach ($actions as $source => $target) {
@@ -238,7 +239,9 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
 
             $this->filesystem->ensureDirectoryExists(dirname($target));
 
-            chdir(dirname($target)); // change directory because the source will be now relative
+            // Change directory because the source will be now relative
+            chdir(dirname($target));
+
             $source = $this->convertPathToRelative($source, $target);
 
             if (!symlink($source, $target)) {
@@ -246,7 +249,8 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
             }
         }
 
-        chdir($workingDir); // restore the previous working directory
+        // Restore the previous working directory
+        chdir($workingDir);
     }
 
     /**

--- a/src/Installer/AbstractModuleInstaller.php
+++ b/src/Installer/AbstractModuleInstaller.php
@@ -230,19 +230,23 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
             }
         }
 
+        $workingDir = getcwd(); // preserve the current working directory
+
         // Only actually create the links if the checks are successful to prevent orphans.
         foreach ($actions as $source => $target) {
             $this->logSymlink($source, $target);
 
             $this->filesystem->ensureDirectoryExists(dirname($target));
 
-            chdir(dirname($target)); // Change directory because the source will be now relative
+            chdir(dirname($target)); // change directory because the source will be now relative
             $source = $this->convertPathToRelative($source, $target);
 
             if (!symlink($source, $target)) {
                 throw new \RuntimeException('Failed to create symlink ' . $target);
             }
         }
+
+        chdir($workingDir); // restore the previous working directory
     }
 
     /**
@@ -256,8 +260,6 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
      */
     protected function convertPathToRelative($source, $target)
     {
-        $relativePath = [];
-
         $sourceParts = array_values(array_filter(explode(DIRECTORY_SEPARATOR, $source)));
         $targetParts = array_values(array_filter(explode(DIRECTORY_SEPARATOR, $target)));
 
@@ -270,6 +272,8 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
             $sourcePartsCounts = count($sourceParts);
             $targetPartsCount  = count($targetParts);
         }
+
+        $relativePath = [];
 
         // start on $i=1 -> skip the link name itself
         for ($i = 1, $count = count($targetParts); $i < $count; $i++) {

--- a/tests/LegacyContaoModuleInstallerTest.php
+++ b/tests/LegacyContaoModuleInstallerTest.php
@@ -74,6 +74,40 @@ class LegacyContaoModuleInstallerTest extends TestCase
     }
 
     /**
+     * Tests that source symlink is relative.
+     *
+     * @return void
+     */
+    public function testSourcesOnInstallIfSymlinkIsRelative()
+    {
+        $installer = $this->createInstaller();
+        $repo      = $this->mockRepository();
+        $package   = $this->mockPackage();
+
+        $basePath = $installer->getInstallPath($package);
+
+        $this->filesystem->ensureDirectoryExists($basePath . '/TL_ROOT/system/modules/foobar/config');
+        touch($basePath . '/TL_ROOT/system/modules/foobar/config/config.php');
+
+        $installer->install($repo, $package);
+
+        $this->assertTrue(file_exists($basePath . '/../../../system/modules/foobar/config/config.php'));
+        $this->assertTrue(is_link($basePath . '/../../../system/modules/foobar/config/config.php'));
+        $this->assertEquals(
+            $basePath . '/TL_ROOT/system/modules/foobar/config/config.php',
+            realpath($basePath . '/../../../system/modules/foobar/config/config.php')
+        );
+
+        $this->assertEquals(
+            $this->filesystem->findShortestPath(
+                $basePath . '/../../../system/modules/foobar/config/config.php',
+                $basePath . '/TL_ROOT/system/modules/foobar/config/config.php'
+            ),
+            readlink($basePath . '/../../../system/modules/foobar/config/config.php')
+        );
+    }
+
+    /**
      * Tests that nothing happens if a symlink is already present and correct.
      *
      * @return void


### PR DESCRIPTION
The absolute paths are wrong because they can lead to errors if e.g. symlinks were created with account/process that is in chroot jail and the web server is not.