### PR TITLE
symlink fallback for windows

### DIFF
--- a/src/Installer/AbstractModuleInstaller.php
+++ b/src/Installer/AbstractModuleInstaller.php
@@ -236,9 +236,16 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
             $this->logSymlink($source, $target);
 
             $this->filesystem->ensureDirectoryExists(dirname($target));
-
-            if (!$this->filesystem->relativeSymlink($source, $target)) {
-                throw new \RuntimeException('Failed to create symlink ' . $target);
+            
+            if('\\' == DIRECTORY_SEPARATOR) {
+                if (!@symlink($source, $target)) {
+                    throw new \RuntimeException('Failed to create absolute symlink (fallback) ' . $target);
+                }
+            }
+            else {
+                if (!$this->filesystem->relativeSymlink($source, $target)) {
+                    throw new \RuntimeException('Failed to create symlink ' . $target);
+                }
             }
         }
     }


### PR DESCRIPTION
see https://github.com/contao-community-alliance/composer-plugin/issues/62

relative symlinks currently do not work under windows (https://github.com/php/php-src/pull/1243); as a workaround use absolute symlinks instead