### PR TITLE
do not expand symlinks to their real path for sources

### DIFF
--- a/src/ContaoCommunityAlliance/Composer/Plugin/CopyInstaller.php
+++ b/src/ContaoCommunityAlliance/Composer/Plugin/CopyInstaller.php
@@ -126,7 +126,7 @@ class CopyInstaller extends AbstractInstaller
                 foreach ($iterator as $sourceFile) {
                     $unPrefixedPath     = self::unprefixPath(
                         $installPath . DIRECTORY_SEPARATOR . ($source ? $source . DIRECTORY_SEPARATOR : ''),
-                        $sourceFile->getRealPath()
+                        $sourceFile->getPathname()
                     );
                     $targetPath         = $target . DIRECTORY_SEPARATOR . $unPrefixedPath;
                     $files[$targetPath] = $sourceFile;


### PR DESCRIPTION
This fixes #72. Whenever you include a package via 
``` 
{
    "type": "path",
    "url": "/path/to/package"
}
```
a symlink to that package is created by composer (within the vendor folder). When `ContaoCommunityAlliance\Composer\Plugin\CopyInstaller::updateAllCopies` is installing the copies for the files defined in 
```
"extra":{
	"contao":{
		"sources":{
			"system/modules/foo_extension": "system/modules/foo_extension"
		}
	}
}
```
it gets the __real__ path to the source files and then removes the Contao install path, to make the path relative. This however will fail in such a case, since
```php
$sourceFile->getRealPath()
```
will then point to the _actual_ location of the repository, which is (probably) not within the Contao root. Thus, as shown in #72, it would try to install the files to
```
/path/to/contao/root/system/modules/foo_extension/path/to/package/system/modules/foo_extension/…
```
instead of
```
/path/to/contao/root/system/modules/foo_extension/…
```
for example.