### PR TITLE
Correctly handle source as symlink

### DIFF
--- a/src/Installer/AbstractModuleInstaller.php
+++ b/src/Installer/AbstractModuleInstaller.php
@@ -516,10 +516,13 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
             );
         }
 
+        $realSource = realpath($source) ?: $source;
+        $realTarget = realpath($target) ?: $target;
+
         if (file_exists($target)) {
             // Target link already exists and is correct, do nothing
             if (is_link($target)
-                && $this->filesystem->normalizePath($source) === $this->filesystem->normalizePath(realpath($target))
+                && $this->filesystem->normalizePath($realSource) === $this->filesystem->normalizePath($realTarget)
             ) {
                 return false;
             }
@@ -551,8 +554,11 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
             return false;
         }
 
+        $realSource = realpath($source) ?: $source;
+        $realTarget = realpath($target) ?: $target;
+
         if (!is_link($target)
-            || $this->filesystem->normalizePath($source) !== $this->filesystem->normalizePath(realpath($target))
+            || $this->filesystem->normalizePath($realSource) !== $this->filesystem->normalizePath($realTarget)
         ) {
             if (self::INVALID_IGNORE === $mode) {
                 return false;
@@ -564,8 +570,8 @@ abstract class AbstractModuleInstaller extends LibraryInstaller
                         '"%s" is not a link to "%s" (expected "%s" but got "%s")',
                         $target,
                         $source,
-                        $this->filesystem->normalizePath($source),
-                        $this->filesystem->normalizePath(realpath($target))
+                        $this->filesystem->normalizePath($realSource),
+                        $this->filesystem->normalizePath($realTarget)
                     )
                 );
             }


### PR DESCRIPTION
If source is a symlink, e.g. because the source is a path repository to the local filesystem, update or remove an extension might fail. Resolving `realpath()` for the source should solve this problem.

Here's the error I got in my local setup:

```
 [RuntimeException]                                                                                                                                                       
  "/Users/aschempp/Sites/isotope49/system/modules/isotope" is not a link to
  "/Users/aschempp/Sites/isotope49/vendor/isotope/isotope-core/system/modules/isotope"
  (expected "/Users/aschempp/Sites/isotope49/vendor/isotope/isotope-core/system/modules/isotope" but got 
  "/Users/aschempp/Projects/Isotope eCommerce/core/system/modules/isotope"  
)  
```